### PR TITLE
Deprecated ArrayHelper, fixed getters

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -9,7 +9,6 @@ use obregonco\B2\Http\Client as HttpClient;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
-use yii\helpers\ArrayHelper;
 
 class Client
 {
@@ -542,8 +541,8 @@ class Client
         ]);
 
         foreach ($files as $file) {
-            if ($file->getName() === $fileName) {
-                return $file->getId();
+            if ($file->getFileName() === $fileName) {
+                return $file->getFileId();
             }
         }
 
@@ -758,7 +757,7 @@ class Client
             $headers['Authorization'] = $this->authToken;
         }
 
-        $options = ArrayHelper::merge([
+        $options = array_replace_recursive([
             'headers' => $headers,
         ], $options);
 


### PR DESCRIPTION
- Fixed getter calls for obregonco\B2\File::getFilename and obregonco\B2\File::getFileId
- yii\helpers\ArrayHelper::merge is not part of this package and it can be replaced by array_replace_recursive

Both changes tested for login, upload and remove.