### PR TITLE
Add ability to submit a prefix to function listFilesFromArray()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -374,6 +374,7 @@ class Client
     {
         // if FileName is set, we only attempt to retrieve information about that single file.
         $fileName = !empty($options['FileName']) ? $options['FileName'] : null;
+		$prefix = !empty($options['Prefix']) ? $options['Prefix'] : null;
 
         $nextFileName = null;
         $maxFileCount = 1000;
@@ -393,6 +394,7 @@ class Client
             $response = $this->request('POST', '/b2_list_file_names', [
                 'json' => [
                     'bucketId' => $options['BucketId'],
+					'prefix' => $prefix,
                     'startFileName' => $nextFileName,
                     'maxFileCount' => $maxFileCount,
                 ],


### PR DESCRIPTION
This is a suggested change to allow the use of the 'prefix' field (see https://www.backblaze.com/b2/docs/b2_list_file_names.html) in the function 'listFilesFromArray()'.

The key in $options is called 'Prefix' (capital) to stay in line with the other options.