### PR TITLE
Update File.php

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -113,7 +113,7 @@ class File implements \JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize():mixed
     {
         return $this->asArray();
     }


### PR DESCRIPTION
Return type of obregonco\B2\File::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice